### PR TITLE
Add back timeout

### DIFF
--- a/engine/network/connection.py
+++ b/engine/network/connection.py
@@ -134,6 +134,7 @@ class NetConnection:
         self.error_string = ""
         self.state = NET_CONNSTATE_CONNECT
         self.send_control(NET_CTRLMSG_CONNECT, SECURITY_TOKEN_MAGIC)
+        self.last_recv_time = time_get()
         return True
 
     def disconnect(self, reason: str = ""):
@@ -171,12 +172,11 @@ class NetConnection:
 
         self.timeout_situation = False
 
-        # TODO: uncomment
-        # if self.state != NET_CONNSTATE_OFFLINE and self.state != NET_CONNSTATE_OFFLINE \
-        #         and (now - self.last_recv_time) > time_freq():
-        #     self.state = NET_CONNSTATE_ERROR
-        #     self.error_string = "Timeout"
-        #     self.timeout_situation = True
+        if self.state != NET_CONNSTATE_OFFLINE and self.state != NET_CONNSTATE_OFFLINE \
+                and (now - self.last_recv_time) > time_freq() * 100:
+            self.state = NET_CONNSTATE_ERROR
+            self.error_string = "Timeout"
+            self.timeout_situation = True
 
         # Fix resends
         # TODO: not sure about this part


### PR DESCRIPTION
TeeAI's time_get is just

	time.time_ns()

And ddnets time_get is

	return std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() - tw_start_time).count();

Which takes the start time into consideration.
The timeout check then fails because time_get() is that much bigger than 0. Since I was too lazy to make TeeAI's time_get to work like tws. I just set last recv on connect which does work too.


Also did add the config timeout part
```C++
if(State() != NET_CONNSTATE_OFFLINE &&
		State() != NET_CONNSTATE_CONNECT &&
		(Now - m_LastRecvTime) > time_freq() * g_Config.m_ConnTimeout)
```

Which is set to 100 by default
```
MACRO_CONFIG_INT(ConnTimeout, conn_timeout, 100, 5, 1000, CFGFLAG_SAVE | CFGFLAG_CLIENT | CFGFLAG_SERVER, "Network timeout")
```