### PR TITLE
Fix sys info being send

### DIFF
--- a/engine/client.py
+++ b/engine/client.py
@@ -138,7 +138,7 @@ class Client:
         msg = MsgPacker(NetMsg.INFO.value)
         msg.add_str(GAME_NETVERSION, 128)
         msg.add_str("", 128)
-        self.send_msg_exy(msg, MsgFlags.VITAL.value | MsgFlags.VITAL.value)
+        self.send_msg_exy(msg, MsgFlags.VITAL.value | MsgFlags.FLUSH.value)
 
     def send_enter_game(self):
         msg = MsgPacker(NetMsg.ENTERGAME.value)

--- a/engine/network/connection.py
+++ b/engine/network/connection.py
@@ -20,7 +20,7 @@ class NetConnection:
         self.last_send_time: int = None
 
         self.error_string: str = None
-        self.construct: NetPacketConstruct = None
+        self.construct: NetPacketConstruct = NetPacketConstruct()
 
         self.peer_address: NetAddr = None
         self.socket: socket = None
@@ -58,7 +58,7 @@ class NetConnection:
         self.construct.ack = self.ack
         NetBase.send_packet(self.socket, self.peer_address, self.construct, self.security_token)
         self.last_send_time = time_get()
-        self.construct = None
+        self.construct = NetPacketConstruct()
         return num_chunks
 
     def queue_chunks_ex(self, flags: int, data: bytearray, sequence: int):

--- a/engine/network/netclient.py
+++ b/engine/network/netclient.py
@@ -51,7 +51,7 @@ class NetClient:
             try:
                 buffer, address = self.socket.recvfrom(NET_MAX_PACKETSIZE)
             except BlockingIOError:
-                continue # caused by non blocking read
+                return False # caused by non blocking read
 
             addr.ip = bytearray(address[0].encode())
             addr.port = address[1]

--- a/engine/network/network.py
+++ b/engine/network/network.py
@@ -44,7 +44,7 @@ class NetChunk:
         self.client_id: int = None
         self.address: NetAddr = None
         self.data: bytearray = None
-        self.flags: int = None
+        self.flags: int = 0
         self.extra_data: None = None
 
     def __len__(self):
@@ -95,14 +95,14 @@ class NetChunkResend:
 
 class NetPacketConstruct:
     def __init__(self, ):
-        self.flags: int = None
+        self.flags: int = 0
         self.ack: int = None
         self.num_chunks: int = 0
         # Size NET_MAX_PAYLOAD
         self.chunk_data: bytearray = bytearray()
         self.chunk_data_index: int = 0
         # Size 4
-        self.extra_data: bytearray = None
+        self.extra_data: bytearray = bytearray()
 
     def __len__(self):
         return len(self.chunk_data)

--- a/engine/packer.py
+++ b/engine/packer.py
@@ -1,31 +1,29 @@
 from .variable_int import VariableInt
-
-PACKER_BUFFER_SIZE = 1024 * 2
-
+from .network.constants import NET_MAX_PAYLOAD
 
 class Packer:
     def __init__(self):
         self.current_index = 0
-        self.buffer = bytearray(PACKER_BUFFER_SIZE)
+        self.buffer = bytearray()
 
     def add_int(self, i: int):
-        if len(self.buffer) - self.current_index < 6:
+        if NET_MAX_PAYLOAD - self.current_index < 6:
             raise BufferError("Not enough space to allocate a variable int.")
         else:
-            self.current_index = VariableInt.pack(self.current_index, self.buffer, i)
+            self.current_index = VariableInt.pack(self.buffer, i, self.current_index)
 
     def add_str(self, string: str, limit: int=0):
         if len(string) > 0:
-            for i, x in enumerate(string):
+            i = 0
+            for b in string.encode():
                 if i >= limit != 0:
                     break
-
-                self.buffer[self.current_index] = x.encode()
+                self.buffer.append(b)
                 self.current_index += 1
                 limit -= 1
 
         # null char at end of str
-        self.buffer[self.current_index] = 0
+        self.buffer.append(0)
         self.current_index += 1
 
     def add_raw(self, data: bytes):
@@ -35,4 +33,4 @@ class Packer:
 
     def reset(self):
         self.current_index = 0
-        self.buffer = bytearray(PACKER_BUFFER_SIZE)
+        self.buffer = bytearray()


### PR DESCRIPTION
```
$ tshark -r ai2.pcap 
    1   0.000000 55915 8303 UDP 57 55915 → 8303 Len=15
    2   0.000072 8303 55915 TW 46 ctrl.accept_connection
    3   0.000087 8303 55915 TW 222 sys.map_change, sys.map_data, sys.con_ready, sys.snap_empty, sys.snap_empty, sys.snap_empty
    4   0.000114 55915 8303 TW 49 ctrl.ack_accept_connection
    5   0.000449 55915 8303 TW 71 sys.info # <=== this is new
    6   1.000648 55915 8303 TW 48 ctrl.keep_alive
```